### PR TITLE
Added title and dismiss button

### DIFF
--- a/Demos/DemoControllers/TomeDemo.swift
+++ b/Demos/DemoControllers/TomeDemo.swift
@@ -1,0 +1,57 @@
+import UIKit
+import FittedSheets
+
+class TomeDemo: UIViewController, Demoable {
+    static var name: String { "Tome" }
+
+    static func openDemo(from parent: UIViewController, in view: UIView?) {
+        let useInlineMode = view != nil
+
+        let viewController = FakeViewController()
+
+        let options = SheetOptions(
+            shouldExtendBackground: false,
+            useFullScreenMode: false,
+            shrinkPresentingViewController: true,
+            useInlineMode: useInlineMode
+        )
+        let sheetViewController = SheetViewController(controller: viewController,
+                                                      sizes: [.percent(0.5), .fullscreen],
+                                                      options: options)
+        sheetViewController.gripSize = CGSize(width: 36.0, height: 5.0)
+        sheetViewController.gripColor = UIColor.white.withAlphaComponent(0.16)
+        sheetViewController.cornerRadius = 24.0
+        if #available(iOS 13.0, *) { // not needed in Tome app
+            sheetViewController.minimumSpaceAbovePullBar = (view?.window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 40.0) + 8.0
+        }
+        sheetViewController.pullBarBackgroundColor = .darkGray
+        sheetViewController.contentBackgroundColor = .darkGray
+        sheetViewController.overlayColor = .clear
+
+        if let view = view {
+            sheetViewController.animateIn(to: view, in: parent)
+        } else {
+            parent.present(sheetViewController, animated: true, completion: nil)
+        }
+    }
+}
+
+class FakeViewController: UITableViewController {
+
+    let cellReuseIdentifier = "cellReuseIdentifier"
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellReuseIdentifier)
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 100
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier, for: indexPath)
+        cell.textLabel?.text = "\(indexPath)"
+        return cell
+    }
+}

--- a/Demos/DemoControllers/TomeDemo.swift
+++ b/Demos/DemoControllers/TomeDemo.swift
@@ -9,11 +9,16 @@ class TomeDemo: UIViewController, Demoable {
 
         let viewController = FakeViewController()
 
+        var dismissButtonImage: UIImage?
+        if #available(iOS 13.0, *) {
+            dismissButtonImage = UIImage(systemName: "xmark.circle")
+        }
         let options = SheetOptions(
             shouldExtendBackground: false,
             useFullScreenMode: false,
             shrinkPresentingViewController: true,
-            useInlineMode: useInlineMode
+            useInlineMode: useInlineMode,
+            dismissButtonImage: dismissButtonImage
         )
         let sheetViewController = SheetViewController(controller: viewController,
                                                       sizes: [.percent(0.5), .fullscreen],
@@ -25,6 +30,12 @@ class TomeDemo: UIViewController, Demoable {
             sheetViewController.minimumSpaceAbovePullBar = (view?.window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 40.0) + 8.0
         }
         sheetViewController.pullBarBackgroundColor = .darkGray
+        sheetViewController.titleBarBackgroundColor = .darkGray
+        sheetViewController.attributedTitle = NSAttributedString(string: "A B C D E F G A B C D E F G A B C D E F G A B C D E F G A B C D E F G A B C D E F G ",
+                                                                 attributes: [
+                                                                    .foregroundColor: UIColor.white,
+                                                                    .font: UIFont.systemFont(ofSize: 18)
+                                                                 ])
         sheetViewController.contentBackgroundColor = .darkGray
         sheetViewController.overlayColor = .clear
 

--- a/Demos/InlineDemosViewController.swift
+++ b/Demos/InlineDemosViewController.swift
@@ -15,7 +15,7 @@ class InlineDemosViewController: UIViewController {
     @IBOutlet var containerView: UIView!
     @IBOutlet var stackViewBottomConstraint: NSLayoutConstraint!
     
-    var demos: [(UIViewController & Demoable).Type] = [
+    var demos: [(UIViewController & Demoable).Type] = [TomeDemo.self] + [
         OnlyCloseWithButtonDemo.self,
         ResizingDemo.self,
         NavigationDemo.self,

--- a/Demos/ModalDemosViewController.swift
+++ b/Demos/ModalDemosViewController.swift
@@ -13,7 +13,7 @@ class ModalDemosViewController: UIViewController {
     @IBOutlet var stackView: UIStackView!
     @IBOutlet var scrollView: UIScrollView!
     
-    var demos: [(UIViewController & Demoable).Type] = [
+    var demos: [(UIViewController & Demoable).Type] = [TomeDemo.self] + [
         OnlyCloseWithButtonDemo.self,
         ResizingDemo.self,
         NavigationDemo.self,

--- a/FittedSheets.xcodeproj/project.pbxproj
+++ b/FittedSheets.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		513F42E9264077B7000E460E /* TomeDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513F42E8264077B7000E460E /* TomeDemo.swift */; };
 		C4E231E524E55E4E00D367FD /* BlurDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E231E424E55E4E00D367FD /* BlurDemo.swift */; };
 		F8034165212625DD00EAD717 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8034164212625DD00EAD717 /* AppDelegate.swift */; };
 		F803416A212625DD00EAD717 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F8034168212625DD00EAD717 /* Main.storyboard */; };
@@ -100,6 +101,7 @@
 
 /* Begin PBXFileReference section */
 		46334410249C041700F334E5 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		513F42E8264077B7000E460E /* TomeDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TomeDemo.swift; sourceTree = "<group>"; };
 		C4E231E424E55E4E00D367FD /* BlurDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurDemo.swift; sourceTree = "<group>"; };
 		F8034161212625DD00EAD717 /* Demos.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demos.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8034164212625DD00EAD717 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -309,6 +311,7 @@
 				F8FAC6B325A38D570042A307 /* HorizontalPaddingDemo.swift */,
 				F8FAC6B825A3930F0042A307 /* MaxWidthDemo.swift */,
 				C4E231E424E55E4E00D367FD /* BlurDemo.swift */,
+				513F42E8264077B7000E460E /* TomeDemo.swift */,
 			);
 			path = DemoControllers;
 			sourceTree = "<group>";
@@ -481,6 +484,7 @@
 				F8FAC6B925A3930F0042A307 /* MaxWidthDemo.swift in Sources */,
 				F857D0B02204D71E004C862F /* TableViewControllerDemo.swift in Sources */,
 				F8034165212625DD00EAD717 /* AppDelegate.swift in Sources */,
+				513F42E9264077B7000E460E /* TomeDemo.swift in Sources */,
 				F83058EE25BF706F00EE17E1 /* MapViewController.swift in Sources */,
 				F8A42B6224D36EA7005DE55B /* IntrinsicInNavigationDemo.swift in Sources */,
 			);

--- a/FittedSheets/SheetContentViewController.swift
+++ b/FittedSheets/SheetContentViewController.swift
@@ -152,12 +152,6 @@ public class SheetContentViewController: UIViewController {
         dismissButton.setImage(self.options.dismissButtonImage, for: .normal)
         dismissButton.addTarget(self, action: #selector(dismissButtonTapped(_:)), for: .touchUpInside)
 
-        // DEBUG
-//        titleLabel.backgroundColor = .blue
-//        dismissButton.backgroundColor = .green
-//        titleLabel.text = "TITLE A B C D E F G A B C D E F G A B C D E F G A B C D E F G A B C D E F G A B C D E F G "
-        // DEBUG
-
         self.contentWrapperView.addSubview(self.titleBarView)
         Constraints(for: self.titleBarView) { view in
             view.top.pinToSuperview(inset: self.titleBarViewTopInset)
@@ -170,7 +164,6 @@ public class SheetContentViewController: UIViewController {
         Constraints(for: self.titleLabel) {
             $0.centerY.alignWithSuperview()
             $0.left.pinToSuperview(inset: self.options.titleBarHorizontalPadding)
-//            $0.right.pinToSuperview(inset: self.options.titleBarHorizontalPadding, relation: .lessThanOrEqual)
         }
 
         self.titleBarView.addSubview(self.dismissButton)

--- a/FittedSheets/SheetContentViewController.swift
+++ b/FittedSheets/SheetContentViewController.swift
@@ -54,6 +54,15 @@ public class SheetContentViewController: UIViewController {
             }
         }
     }
+
+    public var titleBarBackgroundColor: UIColor? {
+        get { return self.titleBarView.backgroundColor }
+        set { self.titleBarView.backgroundColor = newValue }
+    }
+    public var attributedTitle: NSAttributedString? {
+        get { return self.titleLabel.attributedText }
+        set { self.titleLabel.attributedText = newValue }
+    }
     
     weak var delegate: SheetContentViewDelegate?
     
@@ -66,6 +75,9 @@ public class SheetContentViewController: UIViewController {
     public var childContainerView = UIView()
     public var pullBarView = UIView()
     public var gripView = UIView()
+    public var titleBarView = UIView()
+    public var titleLabel = UILabel()
+    public var dismissButton = UIButton()
     private let overflowView = UIView()
     
     public init(childViewController: UIViewController, options: SheetOptions) {
@@ -89,6 +101,7 @@ public class SheetContentViewController: UIViewController {
         self.setupContentView()
         self.setupChildContainerView()
         self.setupPullBarView()
+        self.setupTitleBarView()
         self.setupChildViewController()
         self.updatePreferredHeight()
         self.updateCornerRadius()
@@ -125,6 +138,52 @@ public class SheetContentViewController: UIViewController {
     private func updateCornerRadius() {
         self.contentWrapperView.layer.cornerRadius = self.treatPullBarAsClear ? 0 : self.cornerRadius
         self.childContainerView.layer.cornerRadius = self.treatPullBarAsClear ? self.cornerRadius : 0
+    }
+
+    private var titleBarViewTopInset: CGFloat {
+        return (self.options.pullBarHeight + self.gripSize.height) / 2 + 2
+    }
+
+    private func setupTitleBarView() {
+        guard self.options.shouldExtendBackground == false else { return }
+
+        titleBarView.backgroundColor = self.titleBarBackgroundColor
+        titleLabel.attributedText = self.attributedTitle
+        dismissButton.setImage(self.options.dismissButtonImage, for: .normal)
+        dismissButton.addTarget(self, action: #selector(dismissButtonTapped(_:)), for: .touchUpInside)
+
+        // DEBUG
+//        titleLabel.backgroundColor = .blue
+//        dismissButton.backgroundColor = .green
+//        titleLabel.text = "TITLE A B C D E F G A B C D E F G A B C D E F G A B C D E F G A B C D E F G A B C D E F G "
+        // DEBUG
+
+        self.contentWrapperView.addSubview(self.titleBarView)
+        Constraints(for: self.titleBarView) { view in
+            view.top.pinToSuperview(inset: self.titleBarViewTopInset)
+            view.left.pinToSuperview()
+            view.right.pinToSuperview()
+            view.height.set(self.options.titleBarHeight)
+        }
+
+        self.titleBarView.addSubview(self.titleLabel)
+        Constraints(for: self.titleLabel) {
+            $0.centerY.alignWithSuperview()
+            $0.left.pinToSuperview(inset: self.options.titleBarHorizontalPadding)
+//            $0.right.pinToSuperview(inset: self.options.titleBarHorizontalPadding, relation: .lessThanOrEqual)
+        }
+
+        self.titleBarView.addSubview(self.dismissButton)
+        Constraints(for: self.dismissButton) {
+            $0.centerY.alignWithSuperview()
+            $0.width.set(self.options.dismissButtonSize.width)
+            $0.height.set(self.options.dismissButtonSize.height)
+            $0.right.pinToSuperview(inset: self.options.titleBarHorizontalPadding)
+        }
+
+        NSLayoutConstraint.activate([
+            self.titleLabel.rightAnchor.constraint(lessThanOrEqualTo: self.dismissButton.leftAnchor, constant: -self.options.titleBarHorizontalPadding)
+        ])
     }
     
     private func setupOverflowView() {
@@ -237,7 +296,7 @@ public class SheetContentViewController: UIViewController {
             if self.options.shouldExtendBackground {
                 view.top.pinToSuperview()
             } else {
-                view.top.pinToSuperview(inset: self.options.pullBarHeight)
+                view.top.pinToSuperview(inset: self.titleBarViewTopInset + self.options.titleBarHeight)
             }
             view.left.pinToSuperview()
             view.right.pinToSuperview()
@@ -284,6 +343,10 @@ public class SheetContentViewController: UIViewController {
     
     @objc func pullBarTapped(_ gesture: UITapGestureRecognizer) {
         self.delegate?.pullBarTapped()
+    }
+
+    @objc func dismissButtonTapped(_ button: UIButton) {
+        self.delegate?.dismissButtonTapped()
     }
 }
 

--- a/FittedSheets/SheetContentViewDelegate.swift
+++ b/FittedSheets/SheetContentViewDelegate.swift
@@ -12,6 +12,7 @@ import UIKit
 protocol SheetContentViewDelegate: class {
     func preferredHeightChanged(oldHeight: CGFloat, newSize: CGFloat)
     func pullBarTapped()
+    func dismissButtonTapped()
 }
 
 #endif // os(iOS) || os(tvOS) || os(watchOS)

--- a/FittedSheets/SheetOptions.swift
+++ b/FittedSheets/SheetOptions.swift
@@ -18,6 +18,11 @@ public struct SheetOptions {
         case none
         case automatic
     }
+
+    public var titleBarHeight: CGFloat = 44.0
+    public var titleBarHorizontalPadding: CGFloat = 16.0
+    public var dismissButtonSize = CGSize(width: 24, height: 24)
+    public var dismissButtonImage: UIImage?
     
     public var pullBarHeight: CGFloat = 24
     
@@ -67,7 +72,12 @@ public struct SheetOptions {
                 shrinkPresentingViewController: Bool? = nil,
                 useInlineMode: Bool? = nil,
                 horizontalPadding: CGFloat? = nil,
-                maxWidth: CGFloat? = nil) {
+                maxWidth: CGFloat? = nil,
+                titleBarHeight: CGFloat? = nil,
+                titleBarHorizontalPadding: CGFloat? = nil,
+                dismissButtonSize: CGSize? = nil,
+                dismissButtonImage: UIImage? = nil
+                ) {
         let defaultOptions = SheetOptions.default
         self.pullBarHeight = pullBarHeight ?? defaultOptions.pullBarHeight
         self.presentingViewCornerRadius = presentingViewCornerRadius ?? defaultOptions.presentingViewCornerRadius
@@ -79,6 +89,11 @@ public struct SheetOptions {
         self.horizontalPadding = horizontalPadding ?? defaultOptions.horizontalPadding
         let maxWidth = maxWidth ?? defaultOptions.maxWidth
         self.maxWidth = maxWidth == 0 ? nil : maxWidth
+        self.titleBarHeight = titleBarHeight ?? defaultOptions.titleBarHeight
+        self.titleBarHorizontalPadding = titleBarHorizontalPadding ?? defaultOptions.titleBarHorizontalPadding
+        self.dismissButtonSize = dismissButtonSize ?? defaultOptions.dismissButtonSize
+        self.dismissButtonImage = dismissButtonImage ?? defaultOptions.dismissButtonImage
+
     }
     
     @available(*, unavailable, message: "cornerRadius, minimumSpaceAbovePullBar, gripSize and gripColor are now properties on SheetViewController. Use them instead.")

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -126,6 +126,16 @@ public class SheetViewController: UIViewController {
         get { return self.contentViewController.treatPullBarAsClear }
         set { self.contentViewController.treatPullBarAsClear = newValue }
     }
+
+    public static var titleBarBackgroundColor: UIColor = UIColor.clear
+    public var titleBarBackgroundColor: UIColor? {
+        get { return self.contentViewController.titleBarBackgroundColor }
+        set { self.contentViewController.titleBarBackgroundColor = newValue }
+    }
+    public var attributedTitle: NSAttributedString? {
+        get { return self.contentViewController.attributedTitle }
+        set { self.contentViewController.attributedTitle = newValue }
+    }
     
     let transition: SheetTransition
     
@@ -172,6 +182,7 @@ public class SheetViewController: UIViewController {
         self.gripColor = SheetViewController.gripColor
         self.gripSize = SheetViewController.gripSize
         self.pullBarBackgroundColor = SheetViewController.pullBarBackgroundColor
+        self.titleBarBackgroundColor = SheetViewController.titleBarBackgroundColor
         self.cornerRadius = SheetViewController.cornerRadius
         self.updateOrderedSizes()
         self.modalPresentationStyle = .custom
@@ -730,6 +741,10 @@ extension SheetViewController: SheetContentViewDelegate {
         if self.currentSize == .intrinsic, !self.isPanning {
             self.resize(to: .intrinsic)
         }
+    }
+
+    func dismissButtonTapped() {
+        self.attemptDismiss(animated: true)
     }
 }
 


### PR DESCRIPTION
Instead of building a sheet component from scratch, we're reusing the FittedSheets library. This library is the one that meets our requirements best, see https://www.notion.so/magicaltome/Sheet-f261d97d55cc48559ad66b3c0bf90dca.

One thing that's missing is the header, with a title and a dismiss button. This PR adds that header directly in the sheet component.

Ideally, we'd re-implement this from scratch. The library got a lot of things right, but also quite a few things that could be different or better match our needs. Examples:
- unnecessary option (e.g. `shouldExtendBackground`)
- autolayout issues (in inline mode)
- configuration split between "option" object and setting VC properties
- weird and unnecessary patterns (the "option" init I think could be simplified, certain getter/setters)

The biggest issue that could lead us to reimplement is that the user can't interact with the calling VC (the view behind/underneath the sheet), which we might need for the editor. I checked with Henri and he said it was fine to use this for now and to reimplement later, even if takes some time.